### PR TITLE
Fix integer encoding corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.5.1
+* fix integer encoding corruption
+
+# v0.5.0
+* build on recent Elixir
+
 # v0.4.4
 * fix compilation warning
 * fix documentation url

--- a/lib/bson_encoder.ex
+++ b/lib/bson_encoder.ex
@@ -69,8 +69,8 @@ defmodule Bson.Encoder do
     iex> Cyanide.Encoder.encode 0x8000000000000001
     %Bson.Encoder.Error{what: [Integer], term: 0x8000000000000001}
     """
-    def encode(i) when -0x80000000 <= i and i <= 0x80000000, do: {<<0x10>>, <<i::32-signed-little>>}
-    def encode(i) when -0x8000000000000000 <= i and i <= 0x8000000000000000, do: {<<0x12>>, <<i::64-signed-little>>}
+    def encode(i) when i >= -2_147_483_648 and i <= 2_147_483_647, do: {<<0x10>>, <<i::32-signed-little>>}
+    def encode(i) when i >= -9_223_372_036_854_775_808 and i <= 9_223_372_036_854_775_807, do: {<<0x12>>, <<i::64-signed-little>>}
     def encode(i), do: %Error{what: [Integer], term: i}
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Bson.Mixfile do
     [
       app: :cyanide,
       name: "Cyanide",
-      version: "0.5.0",
+      version: "0.5.1",
       elixir: "~> 1.4",
       description: "BSON implementation for Elixir",
       test_coverage: [tool: ExCoveralls],


### PR DESCRIPTION
Bson.encode(%{v: 2147483648})  was corrupting given value.