### PR TITLE
cyanide: add DateTime.t() to bson_type type

### DIFF
--- a/lib/cyanide.ex
+++ b/lib/cyanide.ex
@@ -26,6 +26,7 @@ defmodule Cyanide do
           | boolean()
           | nil
           | integer()
+          | DateTime.t()
   @type bson_map :: %{optional(String.t()) => bson_type()}
 
   @spec decode(binary()) :: {:ok, bson_map()} | {:error, :invalid_bson}


### PR DESCRIPTION
DateTime is supported but it was not included in the exported type,
causing false errors in dialyzer