### PR TITLE
Add support to protocols

### DIFF
--- a/lib/cyanide/encoded_value.ex
+++ b/lib/cyanide/encoded_value.ex
@@ -1,0 +1,37 @@
+#
+# This file is part of Cyanide.
+#
+# Copyright 2020 Ispirata Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Cyanide.EncodedValue do
+  @moduledoc """
+  Wraps a BSON encoded value.
+
+  ## Fields
+  * `tag` is a type integer tag (such as 0x01, 0x12, ...) as described on the BSON specification.
+  * `data` is the raw encoded value iodata.
+  """
+
+  defstruct [
+    :tag,
+    :data
+  ]
+
+  @type t() :: %__MODULE__{
+          tag: integer(),
+          data: iodata()
+        }
+end

--- a/lib/cyanide/encoder.ex
+++ b/lib/cyanide/encoder.ex
@@ -1,0 +1,67 @@
+#
+# This file is part of Cyanide.
+#
+# Copyright 2020 Ispirata Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defprotocol Cyanide.Encoder do
+  @moduledoc """
+  Protocol controlling how a value is encoded to BSON.
+
+  An encode implementation can either return any encodable value or a Cyanide.EncodedValue struct.
+  In most of the cases returning a map is enough, Cyanide.EncodedValue is meant to be used when a
+  specific BSON type should be enforced.
+  Only maps are supported for root document encoding.
+
+  ## Example
+
+  Let's assume a presence of the following struct:
+
+      defmodule Test do
+        defstruct [:value1, :value2]
+      end
+
+  It can be encoded using the following implementation:
+
+      defimpl Cyanide.Encoder, for: Test do
+        def encode(value) do
+          Map.to_struct(value)
+        end
+      end
+
+  Let's assume that a small value should be always encoded as Int64.
+  This problem can be solved by implementing a wrapper struct.
+
+      defmodule Int64 do
+        defstruct [:value]
+      end
+
+  It can be encoded using the following implementation:
+
+      defimpl Cyanide.Encoder, for: Int64 do
+        def encode(wrapped) do
+          value = wrapped.value
+
+          %Cyanide.EncodedValue{
+            tag: 0x12,
+            data: <<value::signed-little-64>>
+          }
+        end
+      end
+  """
+
+  @spec encode(term()) :: Cyanide.bson_type() | Cyanide.EncodedValue.t()
+  def encode(value)
+end

--- a/mix.exs
+++ b/mix.exs
@@ -24,6 +24,7 @@ defmodule Cyanide.MixProject do
       app: :cyanide,
       version: "1.0.0",
       elixir: "~> 1.6",
+      elixirc_paths: elixirc_paths(Mix.env()),
       deps: deps(),
       package: package(),
       source_url: "https://github.com/ispirata/cyanide",
@@ -36,6 +37,9 @@ defmodule Cyanide.MixProject do
       ]
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   def application do
     [

--- a/test/cyanide_encoding_test.exs
+++ b/test/cyanide_encoding_test.exs
@@ -186,6 +186,48 @@ defmodule CyanideEncodingTest do
     assert Cyanide.encode(%{"value" => nil}) == {:ok, nil_bson_doc}
   end
 
+  test "encode top level struct using map" do
+    test1 = %Test2{
+      a: 0,
+      b: 5
+    }
+
+    assert Cyanide.decode!(Cyanide.encode!(test1)) == %{"a" => 0, "b" => 5}
+  end
+
+  test "encode struct using EncodedValue struct" do
+    map = %{
+      "value1" => %Test1{
+        a: 0,
+        b: 5
+      },
+      value2: %Test1{
+        a: 3,
+        b: 3
+      }
+    }
+
+    assert Cyanide.decode!(Cyanide.encode!(map)) == %{"value1" => false, "value2" => true}
+  end
+
+  test "encode struct using map" do
+    map = %{
+      "value1" => %Test2{
+        a: 1,
+        b: 2
+      },
+      value2: %Test2{
+        a: 3,
+        b: 4
+      }
+    }
+
+    assert Cyanide.decode!(Cyanide.encode!(map)) == %{
+             "value1" => %{"a" => 1, "b" => 2},
+             "value2" => %{"a" => 3, "b" => 4}
+           }
+  end
+
   test "error on unencodable bson" do
     assert Cyanide.encode(%{v: {1}}) == {:error, :cannot_bson_encode}
 

--- a/test/support/test1.ex
+++ b/test/support/test1.ex
@@ -1,0 +1,40 @@
+#
+# This file is part of Cyanide.
+#
+# Copyright 2020 Ispirata Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Test1 do
+  defstruct [
+    :a,
+    :b
+  ]
+end
+
+defimpl Cyanide.Encoder, for: Test1 do
+  def encode(value) do
+    data =
+      if value.a == value.b do
+        1
+      else
+        0
+      end
+
+    %Cyanide.EncodedValue{
+      tag: 0x08,
+      data: <<data::8>>
+    }
+  end
+end

--- a/test/support/test2.ex
+++ b/test/support/test2.ex
@@ -1,0 +1,30 @@
+#
+# This file is part of Cyanide.
+#
+# Copyright 2020 Ispirata Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Test2 do
+  defstruct [
+    :a,
+    :b
+  ]
+end
+
+defimpl Cyanide.Encoder, for: Test2 do
+  def encode(value) do
+    Map.from_struct(value)
+  end
+end


### PR DESCRIPTION
Allow extending BSON encoder by implementing Cyanide.Encoder protocol.