### PR TITLE
Add support to %Cyanide.Binary{} when encoding binaries

### DIFF
--- a/lib/cyanide/binary.ex
+++ b/lib/cyanide/binary.ex
@@ -1,0 +1,48 @@
+#
+# This file is part of Cyanide.
+#
+# Copyright 2020 Ispirata Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Cyanide.Binary do
+  @moduledoc """
+  Represents a binary with a subtype.
+
+  ## Fields
+  * `subtype` is any of `:generic`, `:function`, `:old_binary`, `:old_uuid`, `:uuid`, `:md5`,
+  `:encrypted_bson`, or any user defined value (any integer >= `0x80` and <= `0xFF`).
+  * `data` is a binary (such as `<<0, 1, 2>>` or `"test"`).
+  """
+
+  defstruct [
+    :subtype,
+    :data
+  ]
+
+  @type subtype() ::
+          :generic
+          | :function
+          | :old_binary
+          | :old_uuid
+          | :uuid
+          | :md5
+          | :encrypted_bson
+          | pos_integer()
+
+  @type t() :: %__MODULE__{
+          subtype: pos_integer(),
+          data: binary()
+        }
+end

--- a/test/cyanide_encoding_test.exs
+++ b/test/cyanide_encoding_test.exs
@@ -18,6 +18,7 @@
 
 defmodule CyanideEncodingTest do
   use ExUnit.Case
+  alias Cyanide.Binary
 
   test "encode an empty map" do
     empty_doc = <<5, 0, 0, 0, 0>>
@@ -178,6 +179,13 @@ defmodule CyanideEncodingTest do
     binary_bson_doc = <<20, 0, 0, 0, 5, 98, 105, 110, 0, 5, 0, 0, 0, 0, 0, 1, 0, 2, 0, 0>>
 
     assert Cyanide.encode(%{"bin" => {0, <<0, 1, 0, 2, 0>>}}) == {:ok, binary_bson_doc}
+  end
+
+  test "encode a map with a %Cyanide.Binary{} to bson" do
+    binary_bson_doc = <<20, 0, 0, 0, 5, 98, 105, 110, 0, 5, 0, 0, 0, 0, 0, 1, 0, 2, 0, 0>>
+
+    assert Cyanide.encode(%{"bin" => %Binary{subtype: :generic, data: <<0, 1, 0, 2, 0>>}}) ==
+             {:ok, binary_bson_doc}
   end
 
   test "encode nil value" do


### PR DESCRIPTION
{subtype_int, binary} wasn't handy, use %Cyanide.Binary{} for binaries
instead.

TODO: Use %Cyanide.Binary{} also when decoding.