### PR TITLE
Use %Cyanide.Binary{} when decoding

### DIFF
--- a/lib/cyanide.ex
+++ b/lib/cyanide.ex
@@ -154,11 +154,11 @@ defmodule Cyanide do
     end
   end
 
-  # TODO: Cyanide 2.0: incompatible change, use %Cyanide.Binary{} instead
   defp parse_value(0x5, map, key, <<subdoc_size::little-32, subtype::8, subdoc_and_rest::binary>>) do
     with the_size when the_size >= 0 <- subdoc_size,
-         <<subdocument::binary-size(the_size), rest::binary>> <- subdoc_and_rest do
-      Map.put(map, key, {subtype, subdocument})
+         <<subdocument::binary-size(the_size), rest::binary>> <- subdoc_and_rest,
+         {:ok, subtype_atom} <- Binary.cast_subtype(subtype) do
+      Map.put(map, key, %Binary{subtype: subtype_atom, data: subdocument})
       |> parse_doc_bytes(rest)
     else
       _any ->

--- a/lib/cyanide/binary.ex
+++ b/lib/cyanide/binary.ex
@@ -42,7 +42,22 @@ defmodule Cyanide.Binary do
           | pos_integer()
 
   @type t() :: %__MODULE__{
-          subtype: pos_integer(),
+          subtype: subtype(),
           data: binary()
         }
+
+  @spec cast_subtype(byte) :: {:ok, subtype()} | :error
+  def cast_subtype(value) when is_integer(value) and value < 0xFF do
+    case value do
+      0 -> {:ok, :generic}
+      1 -> {:ok, :function}
+      2 -> {:ok, :old_binary}
+      3 -> {:ok, :old_uuid}
+      4 -> {:ok, :uuid}
+      5 -> {:ok, :md5}
+      6 -> {:ok, :encrypted_bson}
+      x when x >= 0x80 -> {:ok, x}
+      _ -> :error
+    end
+  end
 end

--- a/test/cyanide_binary_test.exs
+++ b/test/cyanide_binary_test.exs
@@ -1,0 +1,38 @@
+#
+# This file is part of Cyanide.
+#
+# Copyright 2021 Ispirata Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule CyanideBinaryTest do
+  use ExUnit.Case
+  alias Cyanide.Binary
+
+  test "decode a valid 0x00 subtype" do
+    assert {:ok, _} = Binary.cast_subtype(0)
+  end
+
+  test "decode a subtype > 0x80 to itself" do
+    assert {:ok, 128} = Binary.cast_subtype(128)
+  end
+
+  test "error on decoding a 0x06 < subtype < 0x80" do
+    assert :error = Binary.cast_subtype(7)
+  end
+
+  test "fail on decoding a non-8-bit binary" do
+    assert catch_error(Binary.cast_subtype(256))
+  end
+end

--- a/test/cyanide_decoding_test.exs
+++ b/test/cyanide_decoding_test.exs
@@ -182,7 +182,21 @@ defmodule CyanideDecodingTest do
   test "decode a single binary value map to bson" do
     binary_bson_doc = <<20, 0, 0, 0, 5, 98, 105, 110, 0, 5, 0, 0, 0, 0, 0, 1, 0, 2, 0, 0>>
 
-    assert Cyanide.decode(binary_bson_doc) == {:ok, %{"bin" => {0, <<0, 1, 0, 2, 0>>}}}
+    assert Cyanide.decode(binary_bson_doc) ==
+             {:ok, %{"bin" => %Cyanide.Binary{subtype: :generic, data: <<0, 1, 0, 2, 0>>}}}
+  end
+
+  test "decode a single binary value map with user defined subtype to bson" do
+    binary_bson_doc = <<20, 0, 0, 0, 5, 98, 105, 110, 0, 5, 0, 0, 0, 129, 0, 1, 0, 2, 0, 0>>
+
+    assert Cyanide.decode(binary_bson_doc) ==
+             {:ok, %{"bin" => %Cyanide.Binary{subtype: 129, data: <<0, 1, 0, 2, 0>>}}}
+  end
+
+  test "error on a single binary value map to bson when 0x06 < subtype < 0x80" do
+    binary_bson_doc = <<20, 0, 0, 0, 5, 98, 105, 110, 0, 5, 0, 0, 0, 7, 0, 1, 0, 2, 0, 0>>
+
+    assert Cyanide.decode(binary_bson_doc) == {:error, :invalid_bson}
   end
 
   test "decode nil value" do

--- a/test/cyanide_test.exs
+++ b/test/cyanide_test.exs
@@ -23,7 +23,7 @@ defmodule CyanideTest do
     map1 = %{
       "t" => DateTime.utc_now() |> DateTime.to_unix(:millisecond),
       "v" => %{
-        "some_binary" => {0, <<0, 0, 0, 0>>},
+        "some_binary" => %Cyanide.Binary{subtype: :generic, data: <<0, 0, 0, 0>>},
         "array" => [1, 2, 3, 4, 5],
         "some_bool" => true,
         "a_string" => "This is a string",
@@ -40,9 +40,9 @@ defmodule CyanideTest do
   test "encodes and decodes a complex map" do
     map2 = %{
       "t" => DateTime.utc_now() |> DateTime.to_unix(:millisecond),
-      "bin1" => {0, <<0, 1, 2, 3>>},
-      "bin2" => {0, <<0>>},
-      "bin3" => {0, <<>>},
+      "bin1" => %Cyanide.Binary{subtype: :generic, data: <<0, 1, 2, 3>>},
+      "bin2" => %Cyanide.Binary{subtype: :generic, data: <<0>>},
+      "bin3" => %Cyanide.Binary{subtype: :generic, data: <<>>},
       "map1" => %{},
       "map2" => %{"a" => true, "b" => false, "c" => nil},
       "map3" => %{


### PR DESCRIPTION
Represents a binary subtype with an atom.