### PR TITLE
Fix decoding of subdocuments

### DIFF
--- a/lib/cyanide.ex
+++ b/lib/cyanide.ex
@@ -124,8 +124,8 @@ defmodule Cyanide do
 
   defp parse_value(0x4, map, key, <<subdoc_size::little-32, subdoc_and_rest::binary>>) do
     with the_size when the_size >= 1 <- subdoc_size - 4,
-         <<subdocument::binary-size(the_size), rest::binary>> <- subdoc_and_rest do
-      array_subdoc = parse_doc_bytes(%{}, subdocument)
+         <<subdocument::binary-size(the_size), rest::binary>> <- subdoc_and_rest,
+         array_subdoc when is_map(array_subdoc) <- parse_doc_bytes(%{}, subdocument) do
       array_max_index = map_size(array_subdoc) - 1
 
       map_array_to_list = fn index, acc ->

--- a/test/cyanide_decoding_test.exs
+++ b/test/cyanide_decoding_test.exs
@@ -197,4 +197,11 @@ defmodule CyanideDecodingTest do
     assert Cyanide.decode(<<3, 0, 0>>) == {:error, :invalid_bson}
     assert Cyanide.decode(<<4, 0, 0, 0>>) == {:error, :invalid_bson}
   end
+
+  test "error on bson with malformed subdocument" do
+    assert Cyanide.decode(
+             <<32, 0, 0, 0, 4, 118, 0, 24, 0, 0, 0, 2, 48, 0, 4, 0, 0, 0, 192, 87, 100, 0, 2, 49,
+               0, 1, 0, 0, 0, 140, 0, 0>>
+           ) == {:error, :invalid_bson}
+  end
 end


### PR DESCRIPTION
Consider the possibility of failure when parsing subdocument bytes. 
Fix crashes when decoding binaries such as `<<32, 0, 0, 0, 4, 118, 0, 24, 0, 0, 0, 2, 48, 0, 4, 0, 0, 0, 192, 87, 100, 0, 2, 49, 0, 1, 0, 0, 0, 140, 0, 0>>.`